### PR TITLE
fix package.json dependency formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
     "@supabase/ssr": "^0.13.2",
-    "@supabase/supabase-js": "^2.39.5"
+    "@supabase/supabase-js": "^2.39.5",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add missing comma after `@supabase/supabase-js` in dependencies

## Testing
- `jq . package.json`
- `npm run build` *(fails: `next: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68963956e94c832c89ef3ca279a4445d